### PR TITLE
Create JPA entities

### DIFF
--- a/src/main/java/com/microjobs/microjobs/helpers/Enums/CompensationType.java
+++ b/src/main/java/com/microjobs/microjobs/helpers/Enums/CompensationType.java
@@ -1,0 +1,7 @@
+package com.microjobs.microjobs.helpers.Enums;
+
+public enum CompensationType {
+    MONEY,
+    SERVICE,
+    ITEM
+}

--- a/src/main/java/com/microjobs/microjobs/helpers/Enums/JobStatus.java
+++ b/src/main/java/com/microjobs/microjobs/helpers/Enums/JobStatus.java
@@ -1,0 +1,10 @@
+package com.microjobs.microjobs.helpers.Enums;
+
+public enum JobStatus {
+    IN_PROGRESS,
+    CLOSED,
+    COMPLETED,
+    OPEN,
+    EXPIRED,
+    CANCELLED
+}

--- a/src/main/java/com/microjobs/microjobs/helpers/Enums/UserRole.java
+++ b/src/main/java/com/microjobs/microjobs/helpers/Enums/UserRole.java
@@ -1,0 +1,6 @@
+package com.microjobs.microjobs.helpers.Enums;
+
+public enum UserRole {
+    USER,
+    ADMIN
+}

--- a/src/main/java/com/microjobs/microjobs/model/Image.java
+++ b/src/main/java/com/microjobs/microjobs/model/Image.java
@@ -1,0 +1,38 @@
+package com.microjobs.microjobs.model;
+
+import java.time.Instant;
+import java.util.UUID;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@Table(name = "image")
+public class Image {
+    @Id
+    @EqualsAndHashCode.Include
+    private UUID id = UUID.randomUUID();
+
+    @NotBlank
+    private String objectKey;
+
+    @NotNull
+    private Instant createdAt;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = true)
+    private Job job;
+}

--- a/src/main/java/com/microjobs/microjobs/model/Interest.java
+++ b/src/main/java/com/microjobs/microjobs/model/Interest.java
@@ -1,0 +1,39 @@
+package com.microjobs.microjobs.model;
+
+import java.time.Instant;
+import java.util.UUID;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@Table(name = "interest")
+public class Interest {
+    @Id
+    @EqualsAndHashCode.Include
+    private UUID id = UUID.randomUUID();
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Job job;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User helper;
+
+    @NotNull
+    private Instant createdAt;
+}

--- a/src/main/java/com/microjobs/microjobs/model/Job.java
+++ b/src/main/java/com/microjobs/microjobs/model/Job.java
@@ -1,0 +1,88 @@
+package com.microjobs.microjobs.model;
+
+import java.time.Instant;
+import java.util.Set;
+import java.util.UUID;
+import com.microjobs.microjobs.helpers.Enums.CompensationType;
+import com.microjobs.microjobs.helpers.Enums.JobStatus;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@Table(name = "job")
+public class Job {
+    @Id
+    @EqualsAndHashCode.Include
+    private UUID id = UUID.randomUUID();
+
+    @NotBlank
+    @Size(min = 1, max = 60)
+    private String title;
+
+    @NotBlank
+    @Size(min = 1, max = 1200)
+    private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User client;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private JobStatus status;
+
+    @NotBlank
+    @Size(max = 80)
+    private String location;
+
+    @NotNull
+    private Instant dueOn;
+
+    @NotNull
+    private Instant createdAt;
+
+    @NotNull
+    private Instant updatedAt;
+
+    @NotNull
+    @Min(value = 15)
+    @Max(value = 360)
+    private int durationMinutes;
+
+    @ElementCollection
+    @Enumerated(EnumType.STRING)
+    @Size(min = 1, max = 3)
+    private Set<CompensationType> compensationType;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(joinColumns = @JoinColumn(name = "job_id", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "tag_id", referencedColumnName = "id"))
+    private Set<Tag> tags;
+
+    @NotNull
+    @OneToMany(fetch = FetchType.LAZY)
+    private Set<Image> images;
+}

--- a/src/main/java/com/microjobs/microjobs/model/Job.java
+++ b/src/main/java/com/microjobs/microjobs/model/Job.java
@@ -83,6 +83,6 @@ public class Job {
     private Set<Tag> tags;
 
     @NotNull
-    @OneToMany(fetch = FetchType.LAZY)
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "job")
     private Set<Image> images;
 }

--- a/src/main/java/com/microjobs/microjobs/model/Match.java
+++ b/src/main/java/com/microjobs/microjobs/model/Match.java
@@ -1,0 +1,40 @@
+package com.microjobs.microjobs.model;
+
+import java.util.UUID;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@Table(name = "match")
+public class Match {
+    @Id
+    @EqualsAndHashCode.Include
+    private UUID id = UUID.randomUUID();
+
+    @NotNull
+    @OneToOne(fetch = FetchType.LAZY)
+    private Job job;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User helper;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User client;
+}

--- a/src/main/java/com/microjobs/microjobs/model/Rating.java
+++ b/src/main/java/com/microjobs/microjobs/model/Rating.java
@@ -27,7 +27,7 @@ import lombok.Setter;
 public class Rating {
     @Id
     @EqualsAndHashCode.Include
-    private UUID id;
+    private UUID id = UUID.randomUUID();
 
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/microjobs/microjobs/model/Rating.java
+++ b/src/main/java/com/microjobs/microjobs/model/Rating.java
@@ -1,0 +1,53 @@
+package com.microjobs.microjobs.model;
+
+import java.time.Instant;
+import java.util.UUID;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@Table(name = "rating")
+public class Rating {
+    @Id
+    @EqualsAndHashCode.Include
+    private UUID id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User rater;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User ratee;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Match match;
+
+    @Min(value = 0)
+    @Max(value = 5)
+    private int stars;
+
+    @Size(max = 300)
+    private String comment;
+
+    @NotNull
+    private Instant createdAt;
+}

--- a/src/main/java/com/microjobs/microjobs/model/Tag.java
+++ b/src/main/java/com/microjobs/microjobs/model/Tag.java
@@ -1,0 +1,38 @@
+package com.microjobs.microjobs.model;
+
+import java.time.Instant;
+import java.util.UUID;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import jakarta.persistence.GenerationType;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@Table(name = "tag")
+public class Tag {
+    @Id
+    @EqualsAndHashCode.Include
+    private UUID id = UUID.randomUUID();
+
+    @NotNull
+    @Size(min = 1, max = 25)
+    @Column(length = 25, unique = true)
+    private String name;
+
+    @NotNull
+    private Instant createdAt;
+}

--- a/src/main/java/com/microjobs/microjobs/model/User.java
+++ b/src/main/java/com/microjobs/microjobs/model/User.java
@@ -1,0 +1,59 @@
+package com.microjobs.microjobs.model;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@Table(name = "_user")
+public class User {
+    @Id
+    private UUID id = UUID.randomUUID();
+
+    @NotNull
+    @Size(min = 1, max = 36)
+    @Column(unique = true)
+    private String name;
+
+    @NotBlank
+    @Email(regexp = "^[a-z0-9._%+-]{1,64}@(terpmail\\.)?umd\\.edu$")
+    @Size(max = 255)
+    @Column(unique = true)
+    private String email;
+
+    @Size(max = 500)
+    private String bio;
+
+    @NotNull
+    private boolean isBanned = false;
+
+    @OneToMany(mappedBy = "helper", fetch = FetchType.LAZY)
+    private Set<Interest> jobInterests = new HashSet<>();
+
+    @OneToMany(mappedBy = "client", fetch = FetchType.LAZY)
+    private Set<Job> jobs = new HashSet<>();
+
+    @NotNull
+    private Instant joinedAt;
+}

--- a/src/main/java/com/microjobs/microjobs/model/User.java
+++ b/src/main/java/com/microjobs/microjobs/model/User.java
@@ -29,6 +29,7 @@ import lombok.Setter;
 @Table(name = "_user")
 public class User {
     @Id
+    @EqualsAndHashCode.Include
     private UUID id = UUID.randomUUID();
 
     @NotNull

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,14 @@
 spring.application.name=microjobs
+
+# Sets common URI prefix for all controllers
+server.servlet.context-path=/api
+
+# H2 DB setup
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=password
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.defer-datasource-initialization=true
+spring.h2.console.enabled=true
+spring.jpa.properties.hibernate.show_sql=true


### PR DESCRIPTION
# Description
Create the database JPA entities representing the data model for the API.
# Testing
Used the H2 memory database console to view the created tables and data relationships, ensuring all entities are created as expected.
